### PR TITLE
fix(pre-commit): exclude Copier files from `yamllint`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,7 @@ repos:
     rev: v5.0.0
     hooks:
       - id: check-added-large-files
+        name: Check for added large files
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.30.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,6 +71,7 @@ repos:
         # 1. SLS files under directory `test/` which are state files
         # 2. `kitchen.vagrant.yml`, which contains Embedded Ruby (ERB) template syntax
         # 3. YAML files heavily reliant on Jinja
+        # 4. `.copier-answers.yml` and related files which are auto-generated
         files: |
           (?x)^(
                 .*\.yaml|
@@ -82,6 +83,7 @@ repos:
           )$
         exclude: |
           (?x)^(
+                \.copier-answers(\..+)?\.ya?ml|
                 kitchen.vagrant.yml|
                 test/.*/states/.*\.sls
           )$


### PR DESCRIPTION
- **fix(pre-commit): exclude Copier files from `yamllint`**
- **fix(pre-commit): improve capitalisation of `check-added-large-files`**
